### PR TITLE
[minor] Allure TestOps: move passed results to watch folder right away

### DIFF
--- a/integration/e2e/watch.cy.ts
+++ b/integration/e2e/watch.cy.ts
@@ -1,0 +1,30 @@
+describe('should move passed test right away @watch', () => {
+  describe('more suite', () => {
+    before(() => {
+      cy.allure().step('some setup');
+    });
+
+    for (let i = 0; i < 10; i++) {
+      it(`test ${i}`, () => {
+        cy.allure().step('hello');
+        cy.allure().startStep('with attach');
+        cy.allure().attachment('out', `test number ${i}`, 'text/plain');
+        cy.allure().endStep();
+
+        cy.allure().startStep('with attach other');
+        cy.allure().attachment('out2', `test number ${i} - attach 2`, 'text/plain');
+        cy.allure().endStep();
+
+        cy.allure().startStep('may fail');
+        cy.wait(1000);
+
+        if (i % 5 === 0) {
+          cy.wrap(null).then(() => {
+            throw new Error('on purpose');
+          });
+        }
+        cy.allure().endStep();
+      });
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^5.44.0",
         "@typescript-eslint/parser": "^5.44.0",
         "allure-commandline": "^2.24.0",
-        "cypress": "^13.3.0",
+        "cypress": "^13.3.3",
         "cypress-redirect-browser-log": "^1.1.2",
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^8.5.0",
@@ -4925,9 +4925,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.0.tgz",
-      "integrity": "sha512-mpI8qcTwLGiA4zEQvTC/U1xGUezVV4V8HQCOYjlEOrVmU1etVvxOjkCXHGwrlYdZU/EPmUiWfsO3yt1o+Q2bgw==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.3.tgz",
+      "integrity": "sha512-mbdkojHhKB1xbrj7CrKWHi22uFx9P9vQFiR0sYDZZoK99OMp9/ZYN55TO5pjbXmV7xvCJ4JwBoADXjOJK8aCJw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -15730,9 +15730,9 @@
       }
     },
     "cypress": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.0.tgz",
-      "integrity": "sha512-mpI8qcTwLGiA4zEQvTC/U1xGUezVV4V8HQCOYjlEOrVmU1etVvxOjkCXHGwrlYdZU/EPmUiWfsO3yt1o+Q2bgw==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.3.tgz",
+      "integrity": "sha512-mbdkojHhKB1xbrj7CrKWHi22uFx9P9vQFiR0sYDZZoK99OMp9/ZYN55TO5pjbXmV7xvCJ4JwBoADXjOJK8aCJw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",
     "allure-commandline": "^2.24.0",
-    "cypress": "^13.3.0",
+    "cypress": "^13.3.3",
     "cypress-redirect-browser-log": "^1.1.2",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
- will move `passed` results with attachments to watch folder right away (when allureAddVideoOnPass is false), failed will be loaded after spec is done