### PR TITLE
[major] custom command wrapping only when chainer returned

### DIFF
--- a/integration/support/index.ts
+++ b/integration/support/index.ts
@@ -44,6 +44,10 @@ Cypress.Commands.add('qaId', (qaId, options = {}) => {
   cy.get(`[data-qa-id="${qaId}"]`, options);
 });
 
+Cypress.Commands.add('qaIdReturn', (qaId, options = {}) => {
+  return cy.get(`[data-qa-id="${qaId}"]`, options);
+});
+
 Cypress.Commands.add('fileExists', (filePath: string) => {
   cy.wait(1000);
   cy.wait(200);

--- a/integration/support/setup.d.ts
+++ b/integration/support/setup.d.ts
@@ -11,6 +11,7 @@ declare namespace Cypress {
     otherCmd(message: string): Chainable<void>;
     fileExists(filePath: string): Chainable<boolean>;
     qaId(selector: string): Chainable<JQuery>;
+    qaIdReturn(selector: string): Chainable<JQuery>;
     promiseTest(delay?: number): Chainable<any>;
   }
 }

--- a/src/setup/custom-commands-handling.ts
+++ b/src/setup/custom-commands-handling.ts
@@ -27,10 +27,15 @@ export class CustomCommandsHandler {
           res.then(() => {
             end();
           });
-        } else {
-          cy.doSyncCommand(() => {
+        } else if (res.should) {
+          res.should(() => {
             end();
           });
+        } else {
+          // when function returns
+          // undefined we cannot add command at the end,
+          // so custom command will be ended immediately
+          end();
         }
 
         return res;

--- a/src/setup/custom-commands-handling.ts
+++ b/src/setup/custom-commands-handling.ts
@@ -27,7 +27,7 @@ export class CustomCommandsHandler {
           res.then(() => {
             end();
           });
-        } else if (res.should) {
+        } else if (res?.should) {
           res.should(() => {
             end();
           });

--- a/tests/test-folder/mocha-events/commands/custom-command-no-return-chain.test.ts
+++ b/tests/test-folder/mocha-events/commands/custom-command-no-return-chain.test.ts
@@ -66,12 +66,11 @@ describe('custom commands', () => {
       expect(steps).toEqual([
         {
           name: 'qaId: link-2',
-          steps: [
-            {
-              name: 'get: [data-qa-id=link-2]',
-              steps: [],
-            },
-          ],
+          steps: [],
+        },
+        {
+          name: 'get: [data-qa-id=link-2]',
+          steps: [],
         },
         {
           name: 'click',
@@ -98,12 +97,11 @@ describe('custom commands', () => {
       expect(steps).toEqual([
         {
           name: 'qaId: link-2',
-          steps: [
-            {
-              name: 'get: [data-qa-id=link-2]',
-              steps: [],
-            },
-          ],
+          steps: [],
+        },
+        {
+          name: 'get: [data-qa-id=link-2]',
+          steps: [],
         },
         {
           name: 'click',
@@ -116,12 +114,11 @@ describe('custom commands', () => {
         },
         {
           name: 'qaId: link-3',
-          steps: [
-            {
-              name: 'get: [data-qa-id=link-3]',
-              steps: [],
-            },
-          ],
+          steps: [],
+        },
+        {
+          name: 'get: [data-qa-id=link-3]',
+          steps: [],
         },
         {
           name: 'click',

--- a/tests/test-folder/mocha-events/commands/custom-command.test.ts
+++ b/tests/test-folder/mocha-events/commands/custom-command.test.ts
@@ -242,11 +242,11 @@ describe('custom commands', () => {
                 { name: 'task: fileExists, nonexistingd2', steps: [] },
               ],
             },
-            {
-              name: 'assert: expected **false** to equal **false**',
-              steps: [],
-            },
           ],
+        },
+        {
+          name: 'assert: expected **false** to equal **false**',
+          steps: [],
         },
       ]);
     });

--- a/tests/test-folder/mocha-events/commands/custom-command.test.ts
+++ b/tests/test-folder/mocha-events/commands/custom-command.test.ts
@@ -116,8 +116,9 @@ describe('custom commands', () => {
       expect(steps).toEqual([
         {
           name: 'tasklog: hello',
-          steps: [{ name: 'task: log, hello', steps: [] }],
+          steps: [],
         },
+        { name: 'task: log, hello', steps: [] },
         {
           name: 'get: div',
           steps: [
@@ -141,11 +142,9 @@ describe('custom commands', () => {
       expect(steps).toEqual([
         {
           name: 'tasklogWithCypressLog: hello',
-          steps: [
-            { name: 'tasklogWithCypressLog: something', steps: [] },
-            { name: 'task: log, hello', steps: [] },
-          ],
+          steps: [{ name: 'tasklogWithCypressLog: something', steps: [] }],
         },
+        { name: 'task: log, hello', steps: [] },
         {
           name: 'get: div',
           steps: [
@@ -169,8 +168,9 @@ describe('custom commands', () => {
       expect(steps).toEqual([
         {
           name: 'tasklog: hello',
-          steps: [{ name: 'task: log, hello', steps: [] }],
+          steps: [],
         },
+        { name: 'task: log, hello', steps: [] },
         {
           name: 'returnGet: hello',
           steps: [
@@ -178,12 +178,11 @@ describe('custom commands', () => {
             { name: 'wrap', steps: [] },
             {
               name: 'get: div:eq(100)',
-              steps: [
-                {
-                  name: 'assert: expected **div:eq(100)** not to exist in the DOM',
-                  steps: [],
-                },
-              ],
+              steps: [],
+            },
+            {
+              name: 'assert: expected **div:eq(100)** not to exist in the DOM',
+              steps: [],
             },
           ],
         },
@@ -214,11 +213,11 @@ describe('custom commands', () => {
             { name: 'wait: 1', steps: [] },
             { name: 'wait: 2', steps: [] },
             { name: 'task: fileExists, nonexistingd', steps: [] },
-            {
-              name: 'assert: expected **false** to equal **false**',
-              steps: [],
-            },
           ],
+        },
+        {
+          name: 'assert: expected **false** to equal **false**',
+          steps: [],
         },
       ]);
     });
@@ -241,11 +240,11 @@ describe('custom commands', () => {
                 { name: 'wait: 1', steps: [] },
                 { name: 'wait: 2', steps: [] },
                 { name: 'task: fileExists, nonexistingd2', steps: [] },
-                {
-                  name: 'assert: expected **false** to equal **false**',
-                  steps: [],
-                },
               ],
+            },
+            {
+              name: 'assert: expected **false** to equal **false**',
+              steps: [],
             },
           ],
         },

--- a/tests/test-folder/mocha-events/commands/do-sync-command.test.ts
+++ b/tests/test-folder/mocha-events/commands/do-sync-command.test.ts
@@ -133,13 +133,12 @@ describe('do sync command', () => {
         {
           name: 'qaId: link-2',
           status: 'passed',
-          steps: [
-            {
-              name: 'get: [data-qa-id=link-2]',
-              status: 'passed',
-              steps: [],
-            },
-          ],
+          steps: [],
+        },
+        {
+          name: 'get: [data-qa-id=link-2]',
+          status: 'passed',
+          steps: [],
         },
         {
           name: 'assert: expected **My link** to equal **My link**',
@@ -177,17 +176,16 @@ describe('do sync command', () => {
         {
           name: 'qaId: link-60',
           status: 'passed',
+          steps: [],
+        },
+        {
+          name: 'get: [data-qa-id=link-60]',
+          status: 'passed',
           steps: [
             {
-              name: 'get: [data-qa-id=link-60]',
+              name: 'assert: expected **[data-qa-id=link-60]** not to exist in the DOM',
               status: 'passed',
-              steps: [
-                {
-                  name: 'assert: expected **[data-qa-id=link-60]** not to exist in the DOM',
-                  status: 'passed',
-                  steps: [],
-                },
-              ],
+              steps: [],
             },
           ],
         },
@@ -211,17 +209,16 @@ describe('do sync command', () => {
         {
           name: 'qaId: link-60',
           status: 'passed',
+          steps: [],
+        },
+        {
+          name: 'get: [data-qa-id=link-60]',
+          status: 'passed',
           steps: [
             {
-              name: 'get: [data-qa-id=link-60]',
+              name: 'assert: expected **[data-qa-id=link-60]** not to exist in the DOM',
               status: 'passed',
-              steps: [
-                {
-                  name: 'assert: expected **[data-qa-id=link-60]** not to exist in the DOM',
-                  status: 'passed',
-                  steps: [],
-                },
-              ],
+              steps: [],
             },
           ],
         },

--- a/tests/test-folder/mocha-events/commands/long-name-command.test.ts
+++ b/tests/test-folder/mocha-events/commands/long-name-command.test.ts
@@ -61,13 +61,12 @@ describe('custom commands', () => {
         {
           attach: [],
           name: 'tasklog1: hello',
-          steps: [
-            {
-              name: 'task: log, hello',
-              attach: [],
-              steps: [],
-            },
-          ],
+          steps: [],
+        },
+        {
+          name: 'task: log, hello',
+          attach: [],
+          steps: [],
         },
       ]);
     });
@@ -98,20 +97,19 @@ describe('custom commands', () => {
               type: 'application/json',
             },
           ],
-          steps: [
+          steps: [],
+        },
+        {
+          name: 'task: log',
+          attach: [
             {
-              attach: [
-                {
-                  name: 'task: log args',
-                  sourceContent:
-                    'log\n012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789',
-                  type: 'application/json',
-                },
-              ],
-              name: 'task: log',
-              steps: [],
+              name: 'task: log args',
+              sourceContent:
+                'log\n012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789',
+              type: 'application/json',
             },
           ],
+          steps: [],
         },
       ]);
     });

--- a/tests/test-folder/mocha-events/steps/group-logs/data-group-log.ts
+++ b/tests/test-folder/mocha-events/steps/group-logs/data-group-log.ts
@@ -191,40 +191,20 @@ describe('${rootSuite}', { defaultCommandTimeout: 300 },() => {
             steps: [
               {
                 attachments: [],
+                name: 'log: level 1',
+                status: 'passed',
+                steps: [],
+              },
+              {
+                attachments: [],
                 name: 'withGroupping',
                 status: 'passed',
                 steps: [
                   {
                     attachments: [],
-                    name: 'log: level 1',
+                    name: 'log: level 2',
                     status: 'passed',
                     steps: [],
-                  },
-                  {
-                    attachments: [],
-                    name: 'withGroupping',
-                    status: 'passed',
-                    steps: [
-                      {
-                        attachments: [],
-                        name: 'withGroupping',
-                        status: 'passed',
-                        steps: [
-                          {
-                            attachments: [],
-                            name: 'log: level 2',
-                            status: 'passed',
-                            steps: [],
-                          },
-                        ],
-                      },
-                      {
-                        attachments: [],
-                        name: 'endLogGroup',
-                        status: 'passed',
-                        steps: [],
-                      },
-                    ],
                   },
                 ],
               },
@@ -238,29 +218,28 @@ describe('${rootSuite}', { defaultCommandTimeout: 300 },() => {
           },
           {
             attachments: [],
+            name: 'endLogGroup',
+            status: 'passed',
+            steps: [],
+          },
+          {
+            attachments: [],
             name: 'withGroupping',
             status: 'passed',
             steps: [
               {
                 attachments: [],
-                name: 'withGroupping',
-                status: 'passed',
-                steps: [
-                  {
-                    attachments: [],
-                    name: 'log: level 1 again',
-                    status: 'passed',
-                    steps: [],
-                  },
-                ],
-              },
-              {
-                attachments: [],
-                name: 'endLogGroup',
+                name: 'log: level 1 again',
                 status: 'passed',
                 steps: [],
               },
             ],
+          },
+          {
+            attachments: [],
+            name: 'endLogGroup',
+            status: 'passed',
+            steps: [],
           },
         ],
       },


### PR DESCRIPTION
With this will stop support of wrapping custom commands in report which doesn't return chainer
like 

```javascript
//  commands within this command will not be wrapped in report with parent 
Cypress.Commands.add('qaId', (qaId, options = {}) => {
  cy.get(`[data-qa-id="${qaId}"]`, options); step
});

 // commands within this command will be wrapped in report with parent step
Cypress.Commands.add('qaIdReturn', (qaId, options = {}) => {
  return cy.get(`[data-qa-id="${qaId}"]`, options);
});

```

So if you wrapping to be in place for custom commands add return's into your commands or as alternative you can add groupping like: 
```
 Cypress.Commands.add('cmdWithGroup', (message: string) => {
    Cypress.log({ name: 'cmdWithGroup', message, groupStart: true });
    cy.log('more steps withing custom command');
    cy.wrap(null).then(()=> {
      Cypress.log({emitOnly: true, groupEnd: true});
    });
  });
  
```

